### PR TITLE
Feat/update to v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="9.1.0"></a>
+
+## 9.1.0 (2020-07-04)
+
+* Reverted Typescript snippets for:
+  * Effects and its setup to support [v7](https://v7.ngrx.io/guide/effects#writing-effects) style of using `@Effect()`
+
 <a name="9.0.0"></a>
 
 ## 9.0.0 (2020-07-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
+<a name="9.0.0"></a>
+
+## 9.0.0 (2020-07-04)
+
+* Updated documentation [`README.md`](https://github.com/hardikpthv/vscode-ngrx-snippets/blob/master/README.md) for new snippets
+* Updated Typescript snippets for:
+  * `ngrx-effect-setup` -> make use of `createEffect`
+  * `ngrx-effect` -> make use of `createEffect`
+  * `ngrx-reducer-setup` -> make use of `createReducer`  
+* Added Typescript snippets for:
+  * `createAction` to create actions
+    * `ngrx-create-action-setup`
+    * `ngrx-create-action`
+    * `ngrx-create-action-props`
+  * `ngrx-root-effect-registration` to register effect in root module
+  * `ngrx-feat-effect-registration` to register effect in feature module
+  * `createReducer` to create reducers
+    * `ngrx-reducer`
+    * `ngrx-on` -> make use of `on`
+  * `StoreDevtoolsModule.instrument` configuration
+  * `createEntityAdapter` to create entity adapter 
+    * `ngrx-entity-adapter-setup`
+  * `EntityMetadataMap` to setup entities
+    * `ngrx-entities-setup`
+    * `ngrx-entity-store-registration` to register entity store
+  * `ngrx-entity-data-service` to create data service using `tEntityCollectionServiceBase`, `tEntityCollectionServiceElementsFactory` and other utility methods.
+
 <a name="0.3.2"></a>
 
-## 0.3.2 (2018-09-08)
+## 0.3.2 (2018-05-30)
 
 * Fixed typo in snippet
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# NgRx Snippets for VS Code
+# NgRx (Version 9) Snippets for VS Code
 
+[![Version](https://vsmarketplacebadge.apphb.com/version/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
+[![Install](https://vsmarketplacebadge.apphb.com/installs/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
+[![Ratings](https://vsmarketplacebadge.apphb.com/rating-short/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
 [![made-for-VSCode](https://img.shields.io/badge/Made%20for-VSCode-1f425f.svg)](https://code.visualstudio.com/)
 
 This extension for Visual Studio Code adds snippets of Typescript for NgRx.
@@ -23,21 +26,35 @@ Start typing `ngrx-*` and hit `enter`, the snippet spreads out.
 
 ### TypeScript Snippets
 
-| Snippet                 | Purpose                                                            |
-| ----------------------- | ------------------------------------------------------------------ |
-| ngrx-actions-setup      | Fully configured Action constants, creators with success and fail. |
-| ngrx-actions-setup-crud | Fully configured Actions for CRUD operations.                      |
-| ngrx-action             | Action                                                             |
-| ngrx-action-success     | Success Action                                                     |
-| ngrx-action-fail        | Fail Action                                                        |
-| ngrx-effect-setup       | Fully configured Effect                                            |
-| ngrx-effect             | Effect                                                             |
-| ngrx-reducer            | Reducer                                                            |
-| ngrx-case               | `case:` for reducer's `switch`                                     |
-| ngrx-selector           | `createSelector()`                                                 |
-| ngrx-feat-selector      | `createFeatureSelector()`                                          |
-| ngrx-store-select       | `store.select()`                                                   |
-| ngrx-dispatch-action    | `store.dispatch()`                                                 |
+| Snippet                        | Purpose                                                            |
+| ------------------------------ | ------------------------------------------------------------------ |
+| ngrx-actions-setup             | Fully configured Action constants, creators with success and fail. |
+| ngrx-create-action-setup       | `createAction` setup                                               |
+| ngrx-create-action             | `createAction`                                                     |
+| ngrx-create-action-props       | `createAction` with `props`                                        |
+| ngrx-actions-setup-crud        | Fully configured Actions for CRUD operations.                      |
+| ngrx-action                    | Action                                                             |
+| ngrx-action-success            | Success Action                                                     |
+| ngrx-action-fail               | Fail Action                                                        |
+| ngrx-effect-setup              | Fully configured Effect using `createEffect`                       |
+| ngrx-effect                    | Effect                                                             |
+| ngrx-root-effect-registration  | Effect Registration for root module                                |
+| ngrx-feat-effect-registration  | Effect Registration for feature module                             |
+| ngrx-reducer                   | Reducer                                                            |
+| ngrx-reducer-setup             | Reducer with state definition                                      |
+| ngrx-on                        | `on`                                                               |
+| ngrx-selector                  | `createSelector()`                                                 |
+| ngrx-feat-selector             | `createFeatureSelector()`                                          |
+| ngrx-store-select              | `store.select()`                                                   |
+| ngrx-dispatch-action           | `store.dispatch()`                                                 |
+| ngrx-devtool-instrument        | Store devtool instrument specification                             |
+| ngrx-entities-setup            | Data entities setup                                                |
+| ngrx-entity-adapter-setup      | Entity adapter                                                     |
+| ngrx-entity-store-registration | Entity store registration                                          |
+| ngrx-entity-data-service       | Entity service data service                                        |
 
-### Using Angular Material
- - Check out [Angular Material Snippets](https://bit.ly/ng-material-vscode)
+### Using Angular Material or Webcomponents 🤔
+
+- Check out:
+  - [Angular Material Snippets](https://bit.ly/ng-material-vscode)
+  - [Webcomponents and Lit Snippets](https://bit.ly/lit-vscode)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ Start typing `ngrx-*` and hit `enter`, the snippet spreads out.
 | ngrx-action                    | Action                                                             |
 | ngrx-action-success            | Success Action                                                     |
 | ngrx-action-fail               | Fail Action                                                        |
-| ngrx-effect-setup              | Fully configured Effect using `createEffect`                       |
+| ngrx-effect-setup              | Fully configured Effect                                            |
 | ngrx-effect                    | Effect                                                             |
+| ngrx-create-effect-setup       | Fully configured Effect using `createEffect`                       |
+| ngrx-create-effect             | `createEffect` function                                            |
 | ngrx-root-effect-registration  | Effect Registration for root module                                |
 | ngrx-feat-effect-registration  | Effect Registration for feature module                             |
 | ngrx-reducer                   | Reducer                                                            |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # NgRx (Version 9) Snippets for VS Code
 
 [![Version](https://vsmarketplacebadge.apphb.com/version/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
-[![Install](https://vsmarketplacebadge.apphb.com/installs/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
+[![Install](https://vsmarketplacebadge.apphb.com/installs-short/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
+[![Downloads](https://vsmarketplacebadge.apphb.com/downloads-short/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
 [![Ratings](https://vsmarketplacebadge.apphb.com/rating-short/hardikpthv.NgRxSnippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.NgRxSnippets)
 [![made-for-VSCode](https://img.shields.io/badge/Made%20for-VSCode-1f425f.svg)](https://code.visualstudio.com/)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "NgRxSnippets",
   "displayName": "NgRx Snippets (Version 9)",
   "description": "NgRx with TypeScript snippets for Angular Apps",
-  "version": "0.3.2",
+  "version": "9.0.0",
   "publisher": "hardikpthv",
   "license": "MIT",
   "icon": "images/ngrx.png",

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "NgRxSnippets",
-    "displayName": "NgRx Snippets",
-    "description": "NgRx with TypeScript snippets for Angular Apps",
-    "version": "0.3.2",
-    "publisher": "hardikpthv",
-    "license": "MIT",
-    "icon": "images/ngrx.png",
-    "galleryBanner": {
-        "color": "#eff1f3",
-        "theme": "light"
-    },
-    "homepage": "https://github.com/hardikpthv/vscode-ngrx-snippets/blob/master/README.md",
-    "bugs": {
-        "url": "https://github.com/hardikpthv/vscode-ngrx-snippets/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/hardikpthv/vscode-ngrx-snippets.git"
-    },
-    "keywords": [
-        "ngrx",
-        "ngrx-effects",
-        "Angular",
-        "Reactive",
-        "TypeScript"
-    ],
-    "engines": {
-        "vscode": "^1.10.0"
-    },
-    "categories": [
-        "Snippets"
-    ],
-    "contributes": {
-        "snippets": [
-            {
-                "language": "typescript",
-                "path": "./snippets/typescript.json"
-            }
-        ]
-    }
+  "name": "NgRxSnippets",
+  "displayName": "NgRx Snippets (Version 9)",
+  "description": "NgRx with TypeScript snippets for Angular Apps",
+  "version": "0.3.2",
+  "publisher": "hardikpthv",
+  "license": "MIT",
+  "icon": "images/ngrx.png",
+  "galleryBanner": {
+    "color": "#eff1f3",
+    "theme": "light"
+  },
+  "homepage": "https://github.com/hardikpthv/vscode-ngrx-snippets/blob/master/README.md",
+  "bugs": {
+    "url": "https://github.com/hardikpthv/vscode-ngrx-snippets/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hardikpthv/vscode-ngrx-snippets.git"
+  },
+  "keywords": [
+    "ngrx",
+    "ngrx-effects",
+    "Angular",
+    "Reactive",
+    "TypeScript"
+  ],
+  "engines": {
+    "vscode": "^1.10.0"
+  },
+  "categories": [
+    "Snippets"
+  ],
+  "contributes": {
+    "snippets": [
+      {
+        "language": "typescript",
+        "path": "./snippets/typescript.json"
+      }
+    ]
+  }
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -174,9 +174,9 @@
       "}\n"
     ]
   },
-  "NgRx Effects Setup": {
-    "prefix": "ngrx-effect-setup",
-    "description": "NgRx effect setup",
+  "NgRx Create Effect Setup": {
+    "prefix": "ngrx-create-effect-setup",
+    "description": "NgRx create effect setup",
     "body": [
       "import { Injectable } from '@angular/core';",
       "import { Actions, createEffect, ofType } from '@ngrx/effects';",
@@ -204,9 +204,9 @@
       "}"
     ]
   },
-  "NgRx Effect": {
-    "prefix": "ngrx-effect",
-    "description": "NgRx effect",
+  "NgRx Create Effect": {
+    "prefix": "ngrx-create-effect",
+    "description": "NgRx create effect",
     "body": [
       "${1:effectName}$ = createEffect(() =>",
       "\tthis.actions$.pipe(",
@@ -218,6 +218,54 @@
       "\t\t\t*/",
       "\t\t})",
       "\t)",
+      ");"
+    ]
+  },
+  "NgRx Effects Setup": {
+    "prefix": "ngrx-effect-setup",
+    "description": "NgRx effect setup",
+    "body": [
+      "import { Injectable } from '@angular/core';",
+      "import { Actions, Effect, ofType } from '@ngrx/effects';",
+      "",
+      "// import { of } from 'rxjs';",
+      "import { catchError, map, switchMap } from 'rxjs/operators';",
+      "",
+      "import * as ${2:alias} from '${1:actions}';",
+      "//import all requried services or any dependencies",
+      "",
+      "@Injectable()",
+      "export class ${3:Name}Effects {",
+      "\tconstructor(private action$: Actions) { }",
+      "",
+      "\t@Effect()",
+      "\t${4:effectName}$ = this.action$.pipe(",
+      "\t\tofType(${2}${5:ACTION_TYPE}),",
+      "\t\tswitchMap(() => {",
+      "\t\t\t/*return this.myService().pipe(",
+      "\t\t\t\tmap(data => data),",
+      "\t\t\t\tcatchError(error => of(error))",
+      "\t\t\t\t//dispatch action with payload in `map`",
+      "\t\t\t\t//dispatch action with error in `catchError`",
+      "\t\t\t);*/",
+      "\t\t})",
+      "\t);",
+      "}"
+    ]
+  },
+  "NgRx Effect": {
+    "prefix": "ngrx-effect",
+    "description": "NgRx effect",
+    "body": [
+      "@Effect()",
+      "${1:effectName}$ = this.action$.pipe(",
+      "\tofType(${2:ACTION_TYPE}),",
+      "\tswitchMap(() => {",
+      "\t\t/*return this.myService().pipe(",
+      "\t\t\tmap(data => data),",
+      "\t\t\tcatchError(error => error)",
+      "\t\t);*/",
+      "\t})",
       ");"
     ]
   },

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -24,6 +24,34 @@
             "export type Actions = ${2} | ${2}Success | ${2}Fail;"
         ]
     },
+    "NgRx Create Action Setup": {
+        "prefix": "ngrx-create-action-setup",
+        "description": "NgRx create action setup.",
+        "body": [
+            "import { createAction } from '@ngrx/store';",
+            "// ${1} action",
+            "export const ${1:action} = createAction('[${2:source}] ${3:event}');"
+        ]
+    },
+    "NgRx Create Action": {
+        "prefix": "ngrx-create-action",
+        "description": "NgRx create action.",
+        "body": [            
+            "// ${1} action",
+            "export const ${1:action} = createAction('[${2:source}] ${3:event}');"
+        ]
+    },
+    "NgRx Create Action with Props": {
+        "prefix": "ngrx-create-action-props",
+        "description": "NgRx create action with props.",
+        "body": [            
+            "// ${1} action",
+            "export const ${1:action} = createAction(",
+            "\t'[${2:source}] ${3:event}',",
+            "\t props<{${4:key}: ${5:type}}>()",
+            ");"
+        ]
+    },
     "NgRx Actions CRUD Setup": {
         "prefix": "ngrx-actions-setup-crud",
         "description": "NgRx actions for CRUD operations.",
@@ -151,28 +179,27 @@
         "description": "NgRx effect setup",
         "body": [
             "import { Injectable } from '@angular/core';",
-            "import { Actions, Effect } from '@ngrx/effects';",
-            "",
-            "import { of } from 'rxjs';",
-            "import { catchError, map, switchMap } from 'rxjs/operators';",
+            "import { Actions, createEffect, ofType } from '@ngrx/effects';",            
+            "// import { EMPTY } from 'rxjs';",
+            "// import { map, mergeMap, catchError } from 'rxjs/operators';",
             "",
             "import * as ${2:alias} from '${1:actions}';",
             "//import all requried services or any dependencies",
             "",
             "@Injectable()",
             "export class ${3:Name}Effects {",
-            "\tconstructor(private action$: Actions) { }",
+            "\tconstructor(private actions$: Actions) { }",
             "",
-            "\t@Effect()",
-            "\t${4:effectName}$ = this.action$.ofType(${2}${5:ACTION_TYPE}).pipe(",
-            "\t\tswitchMap(() => {",
-            "\t\t\t/*return this.myService().pipe(",
-            "\t\t\t\tmap(data => data),",
-            "\t\t\t\tcatchError(error => of(error))",
-            "\t\t\t\t//dispatch action with payload in `map`",
-            "\t\t\t\t//dispatch action with error in `catchError`",
-            "\t\t\t);*/",
-            "\t\t})",
+            "\t${4:effectName}$ = createEffect(() =>",
+            "\t\tthis.actions$.pipe(",
+            "\t\t\tofType(${2}${5:action}),",
+            "\t\t\tmergeMap(() => {",
+            "\t\t\t\t/*this.myService.pipe(",
+            "\t\t\t\t\tmap(data => data)",            
+            "\t\t\t\t\tcatchError(() => EMPTY)",
+            "\t\t\t\t*/",
+            "\t\t\t})",
+            "\t\t)",
             "\t);",
             "}"
         ]
@@ -181,49 +208,75 @@
         "prefix": "ngrx-effect",
         "description": "NgRx effect",
         "body": [
-            "@Effect()",
-            "${1:effectName}$ = this.action$.ofType(${2:ACTION_TYPE}).pipe(",
-            "\tswitchMap(() => {",
-            "\t\t/*return this.myService().pipe(",
-            "\t\t\tmap(data => data),",
-            "\t\t\tcatchError(error => error)",
-            "\t\t);*/",
-            "\t})",
+            "${1:effectName}$ = createEffect(() =>",
+            "\tthis.actions$.pipe(",
+            "\t\tofType(${2:action}),",
+            "\t\tmergeMap(() => {",
+            "\t\t\t/*this.myService.pipe(",
+            "\t\t\t\tmap(data => data)",            
+            "\t\t\t\tcatchError(() => EMPTY)",
+            "\t\t\t*/",
+            "\t\t})",
+            "\t)",
             ");"
         ]
     },
+    "NgRx Root Effect Registration": {
+        "prefix": "ngrx-root-effect-registration",
+        "description": "NgRx Root Effect Registration.\nimport { EffectsModule } from '@ngrx/effects';",
+        "body": [
+            "EffectsModule.forRoot([${1:effect}])"
+        ]
+    },
+    "NgRx Feature Effect Registration": {
+        "prefix": "ngrx-feat-effect-registration",
+        "description": "NgRx Feature Effect Registration.\nimport { EffectsModule } from '@ngrx/effects';",
+        "body": [
+            "EffectsModule.forFeature([${1:effect}])"
+        ]
+    },
     "NgRx Reducer Setup": {
-        "prefix": "ngrx-reducer",
+        "prefix": "ngrx-reducer-setup",
         "description": "NgRx reducer setup",
         "body": [
-            "import * as ${2:alias} from '${1:actions}';",
-            "//import or declare state",
+            "import { Action, createReducer, on } from '@ngrx/store';",                        
+            "import * as ${2:alias} from '${1:actions}';",            
+            "",
+            "export interface State {",
+            "\t// define state ",
+            "};",
             "",
             "export const initialState = {",
             "\t//set initial state",
             "};",
-            "export function ${3:name}Reducer(state = initialState, action: ${2}${4:AllActions}) {",
-            "\tswitch (action.type) {",
-            "\t\tcase ${2}${5:ACTION_TYPE}: {",
-            "\t\t\t//add your code",
-            "\t\t\treturn { ...state };",
-            "\t\t}",
             "",
-            "\t\tdefault: ",
-            "\t\t\treturn state;",
-            "\t}",
+            "const ${3:feature}Reducer = createReducer(",
+            "\tinitialState,",
+            "\ton(${2}${4:action}, state => ({ ...state, ${5:prop}: ${6:newValue} })),",            
+            ");",
+            "export function reducer(state: State, action: Action) {",
+            "\treturn ${3}Reducer(state, action);",
+            "}"            
+        ]
+    },
+    "NgRx Reducer": {
+        "prefix": "ngrx-reducer",
+        "description": "NgRx reducer",
+        "body": [            
+            "const ${1:feature}Reducer = createReducer(",
+            "\tinitialState,",
+            "\ton(${2:action}, state => ({ ...state, ${3:prop}: ${4:newValue} })),",            
+            ");",
+            "export function reducer(state: State, action: Action) {",
+            "\treturn ${1}Reducer(state, action);",
             "}"
         ]
     },
-    "NgRx Reducer Switch Case": {
-        "prefix": "ngrx-case",
-        "description": "NgRx Reducer Switch Case",
+    "NgRx Reducer Ons": {
+        "prefix": "ngrx-on",
+        "description": "NgRx Reducer 'On'",
         "body": [
-            "case ${1:alias}${2:ACTION_TYPE}: {",
-            "\t//add your code",
-            "\treturn { ...state };",
-            "}",
-            ""
+            "on(${1:action}, state => ({ ...state, ${2:prop}: ${3:newValue} })),"
         ]
     },
     "NgRx Select Store": {
@@ -253,6 +306,96 @@
         "description": "NgRx Feature Selector",
         "body": [
             "export const get${3:state} = createFeatureSelector<${2:any}>('${1:selector}');"
+        ]
+    },
+    "NgRx Devtool Instrument": {
+        "prefix": "ngrx-devtool-instrument",
+        "description": "NgRx Devltool Instrument.\nimport { StoreDevtoolsModule } from '@ngrx/store-devtools'",
+        "body": [
+            "StoreDevtoolsModule.instrument({",
+            "\tmaxAge: ${1:maxAge},",
+            "\tlogOnly: false,",
+            "\tfeatures: {",
+            "\t\tpause: false,",
+            "\t\tlock: true,",
+            "\t\tpersist: true",
+            "\t}",
+            "})"
+        ]
+    },
+    "NgRx Entity Adapter Setup": {
+        "prefix": "ngrx-entity-adapter-setup",
+        "description": "NgRx Entity Adapter.",
+        "body": [
+            "import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';",
+            "",
+            "export interface ${1:CustomEntity} {",
+            "\t// define properties",
+            "}",
+            "",
+            "export interface State extends EntityState<${1}> {",
+            "\t// define entities state properties",
+            "}",            
+            "\n// define methods to be used in adapter\n",
+            "export const adapter: EntityAdapter<${1}> = createEntityAdapter<${1}>({",
+            "\t// define adapter methods",
+            "});"
+        ]
+    },
+    "NgRx Entities Setup": {
+        "prefix": "ngrx-entities-setup",
+        "description": "NgRx Entities Setup",
+        "body": [
+            "import { EntityMetadataMap } from '@ngrx/data';",
+            "",
+            "const entityMetadata: EntityMetadataMap = {",
+            "\t// define entities",
+            "}",
+            "",
+            "export const entityConfig = {",
+            "\t// entities",
+            "}"
+        ]
+    },
+    "NgRx Entity Store Registration": {
+        "prefix": "ngrx-entity-store-registration",
+        "description": "NgRx Entity Store Registration.\nimport { DefaultDataServiceConfig, EntityDataModule } from '@ngrx/data';",
+        "body": [
+            "EntityDataModule.forRoot([${1:entityConfig}])"
+        ]
+    },
+    "NgRx Entity Data Service": {
+        "prefix": "ngrx-entity-data-service",
+        "description": "NgRx Entity Data Service.",
+        "body": [
+            "import { Injectable } from '@angular/core';",
+            "import {",
+            "\tEntityCollectionServiceBase,",
+            "\tEntityCollectionServiceElementsFactory",
+            "\tQueryParams",
+            "} from '@ngrx/data';",
+
+            "import { Observable } from 'rxjs';",
+            "import { ${2:model} } from '${1:modelPath}';",
+            "",
+            "@Injectable({ providedIn: 'root' })",
+            "export class ${2}Service extends EntityCollectionServiceBase<${2}> {",
+            "\tconstructor(serviceElementsFactory: EntityCollectionServiceElementsFactory) {",
+            "\t\tsuper('${2}', serviceElementsFactory);",
+            "\t}",
+            "",
+            "\tgetAll(): Observable<${2}[]> {",
+            "\t\treturn super.getAll().pipe(/*data manupulation*/);",
+            "\t}",
+            "",
+            "\tgetById(id: string | number): Observable<${2}> {",
+            "\t\treturn super.getById(id).pipe(/*data manupulation*/);",
+            "\t}",
+            "",
+            "\tgetWithQuery(params: string | QueryParams): Observable<${2}[]> {",
+            "\t\treturn super.getWithQuery(params).pipe(/*data manupulation*/);",
+            "\t}",
+            "}"
         ]
     }
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -1,401 +1,391 @@
 {
-    "NgRx Actions Setup": {
-        "prefix": "ngrx-actions-setup",
-        "description": "NgRx actions fully configured with action constants, creators with success and fail.",
-        "body": [
-            "import { Action } from '@ngrx/store';",
-            "",
-            "export const ${1:ACTION_CONST} = \"${1/[\\_]/ /g}\"",
-            "export const ${1}_SUCCESS = \"${1/[\\_]/ /g} SUCCESS\"",
-            "export const ${1}_FAIL = \"${1/[\\_]/ /g} FAIL\"",
-            "",
-            "export class ${2:ActionCreator} implements Action {",
-            "\treadonly type = ${1};",
-            "\tconstructor() { }",
-            "}\n",
-            "export class ${2}Success implements Action {",
-            "\treadonly type = ${1}_SUCCESS;",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export class ${2}Fail implements Action {",
-            "\treadonly type = ${1}_FAIL;",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export type Actions = ${2} | ${2}Success | ${2}Fail;"
-        ]
-    },
-    "NgRx Create Action Setup": {
-        "prefix": "ngrx-create-action-setup",
-        "description": "NgRx create action setup.",
-        "body": [
-            "import { createAction } from '@ngrx/store';",
-            "// ${1} action",
-            "export const ${1:action} = createAction('[${2:source}] ${3:event}');"
-        ]
-    },
-    "NgRx Create Action": {
-        "prefix": "ngrx-create-action",
-        "description": "NgRx create action.",
-        "body": [            
-            "// ${1} action",
-            "export const ${1:action} = createAction('[${2:source}] ${3:event}');"
-        ]
-    },
-    "NgRx Create Action with Props": {
-        "prefix": "ngrx-create-action-props",
-        "description": "NgRx create action with props.",
-        "body": [            
-            "// ${1} action",
-            "export const ${1:action} = createAction(",
-            "\t'[${2:source}] ${3:event}',",
-            "\t props<{${4:key}: ${5:type}}>()",
-            ");"
-        ]
-    },
-    "NgRx Actions CRUD Setup": {
-        "prefix": "ngrx-actions-setup-crud",
-        "description": "NgRx actions for CRUD operations.",
-        "body": [
-            "import { Action } from '@ngrx/store';",
-            "",
-            "export const ${1:ACTION_CONST} = \"${1/[\\_]/ /g}\"",
-            "export const ${1}_SUCCESS = \"${1/[\\_]/ /g} SUCCESS\"",
-            "export const ${1}_FAIL = \"${1/[\\_]/ /g} FAIL\"",
-            "",
-            "export class Load${2:ActionCreator} implements Action {",
-            "\treadonly type = ${1};",
-            "}\n",
-            "export class Load${2}Success implements Action {",
-            "\treadonly type = ${1}_SUCCESS;",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export class Load${2}Fail implements Action {",
-            "\treadonly type = ${1}_FAIL;",
-            "\tconstructor(public payload: any) { }",
-            "}",
-            "",
-            "export const CREATE_${3:ACTION_CONST} = \"CREATE ${3}\"",
-            "export const CREATE_${3}_SUCCESS = \"CREATE ${3} SUCCESS\"",
-            "export const CREATE_${3}_FAIL = \"CREATE ${3} FAIL\"",
-            "",
-            "export class Create${4:ActionCreator} implements Action {",
-            "\treadonly type = CREATE_${3};",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export class Create${4}Success implements Action {",
-            "\treadonly type = CREATE_${3}_SUCCESS;",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export class Create${4}Fail implements Action {",
-            "\treadonly type = CREATE_${3}_FAIL;",
-            "\tconstructor(public payload: any) { }",
-            "}",
-            "",
-            "export const UPDATE_${3} = \"UPDATE ${3}\"",
-            "export const UPDATE_${3}_SUCCESS = \"UPDATE ${3} SUCCESS\"",
-            "export const UPDATE_${3}_FAIL = \"UPDATE ${3} FAIL\"",
-            "",
-            "export class Update${4} implements Action {",
-            "\treadonly type = UPDATE_${3};",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export class Update${4}Success implements Action {",
-            "\treadonly type = UPDATE_${3}_SUCCESS;",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export class Update${4}Fail implements Action {",
-            "\treadonly type = UPDATE_${3}_FAIL;",
-            "\tconstructor(public payload: any) { }",
-            "}",
-            "",
-            "export const DELETE_${3} = \"DELETE ${3:ACTION_STR}\"",
-            "export const DELETE_${3}_SUCCESS = \"DELETE ${3} SUCCESS\"",
-            "export const DELETE_${3}_FAIL = \"DELETE ${3} FAIL\"",
-            "",
-            "export class Delete${4:ActionCreator} implements Action {",
-            "\treadonly type = DELETE_${3};",
-            "\tconstructor(public id: number) { }",
-            "}\n",
-            "export class Delete${4}Success implements Action {",
-            "\treadonly type = DELETE_${3}_SUCCESS;",
-            "\tconstructor(public payload: any) { }",
-            "}\n",
-            "export class Delete${4}Fail implements Action {",
-            "\treadonly type = DELETE_${3}_FAIL;",
-            "\tconstructor(public payload: any) { }",
-            "}",
-            "",
-            "export type Actions =",
-            "\t| Load${2}",
-            "\t| Load${2}Success",
-            "\t| Load${2}Fail",
-            "\t| Create${4}",
-            "\t| Create${4}Success",
-            "\t| Create${4}Fail",
-            "\t| Update${4}",
-            "\t| Update${4}Success",
-            "\t| Update${4}Fail",
-            "\t| Delete${4}",
-            "\t| Delete${4}Success",
-            "\t| Delete${4}Fail;",
-            ""
-        ]
-    },
-    "NgRx Basic Action": {
-        "prefix": "ngrx-action",
-        "description": "NgRx action constant and creator.",
-        "body": [
-            "export const ${1:ACTION_CONST} = \"${1/[\\_]/ /g}\"\n",
-            "export class ${2:ActionCreator} implements Action {",
-            "\treadonly type = ${1};",
-            "\tconstructor() { }",
-            "}\n"
-        ]
-    },
-    "NgRx Success Action": {
-        "prefix": "ngrx-action-success",
-        "description": "NgRx action constant and creator as success",
-        "body": [
-            "export const ${1:ACTION_CONST}_SUCCESS = \"${1/[\\_]/ /g} SUCCESS\"\n",
-            "export class ${2:ActionCreator}Success implements Action {",
-            "\treadonly type = ${1}_SUCCESS;",
-            "\tconstructor(public payload: any) { }",
-            "}\n"
-        ]
-    },
-    "NgRx Fail Action": {
-        "prefix": "ngrx-action-fail",
-        "description": "NgRx action constant and creator as  fail.",
-        "body": [
-            "export const ${1:ACTION_CONST}_FAIL = \"${1/[\\_]/ /g} FAIL\"\n",
-            "export class ${3:ActionCreator} implements Action {",
-            "\treadonly type = ${1}_FAIL;",
-            "\tconstructor(public payload: any) { }",
-            "}\n"
-        ]
-    },
-    "NgRx Effects Setup": {
-        "prefix": "ngrx-effect-setup",
-        "description": "NgRx effect setup",
-        "body": [
-            "import { Injectable } from '@angular/core';",
-            "import { Actions, createEffect, ofType } from '@ngrx/effects';",            
-            "// import { EMPTY } from 'rxjs';",
-            "// import { map, mergeMap, catchError } from 'rxjs/operators';",
-            "",
-            "import * as ${2:alias} from '${1:actions}';",
-            "//import all requried services or any dependencies",
-            "",
-            "@Injectable()",
-            "export class ${3:Name}Effects {",
-            "\tconstructor(private actions$: Actions) { }",
-            "",
-            "\t${4:effectName}$ = createEffect(() =>",
-            "\t\tthis.actions$.pipe(",
-            "\t\t\tofType(${2}${5:action}),",
-            "\t\t\tmergeMap(() => {",
-            "\t\t\t\t/*this.myService.pipe(",
-            "\t\t\t\t\tmap(data => data)",            
-            "\t\t\t\t\tcatchError(() => EMPTY)",
-            "\t\t\t\t*/",
-            "\t\t\t})",
-            "\t\t)",
-            "\t);",
-            "}"
-        ]
-    },
-    "NgRx Effect": {
-        "prefix": "ngrx-effect",
-        "description": "NgRx effect",
-        "body": [
-            "${1:effectName}$ = createEffect(() =>",
-            "\tthis.actions$.pipe(",
-            "\t\tofType(${2:action}),",
-            "\t\tmergeMap(() => {",
-            "\t\t\t/*this.myService.pipe(",
-            "\t\t\t\tmap(data => data)",            
-            "\t\t\t\tcatchError(() => EMPTY)",
-            "\t\t\t*/",
-            "\t\t})",
-            "\t)",
-            ");"
-        ]
-    },
-    "NgRx Root Effect Registration": {
-        "prefix": "ngrx-root-effect-registration",
-        "description": "NgRx Root Effect Registration.\nimport { EffectsModule } from '@ngrx/effects';",
-        "body": [
-            "EffectsModule.forRoot([${1:effect}])"
-        ]
-    },
-    "NgRx Feature Effect Registration": {
-        "prefix": "ngrx-feat-effect-registration",
-        "description": "NgRx Feature Effect Registration.\nimport { EffectsModule } from '@ngrx/effects';",
-        "body": [
-            "EffectsModule.forFeature([${1:effect}])"
-        ]
-    },
-    "NgRx Reducer Setup": {
-        "prefix": "ngrx-reducer-setup",
-        "description": "NgRx reducer setup",
-        "body": [
-            "import { Action, createReducer, on } from '@ngrx/store';",                        
-            "import * as ${2:alias} from '${1:actions}';",            
-            "",
-            "export interface State {",
-            "\t// define state ",
-            "};",
-            "",
-            "export const initialState = {",
-            "\t//set initial state",
-            "};",
-            "",
-            "const ${3:feature}Reducer = createReducer(",
-            "\tinitialState,",
-            "\ton(${2}${4:action}, state => ({ ...state, ${5:prop}: ${6:newValue} })),",            
-            ");",
-            "export function reducer(state: State, action: Action) {",
-            "\treturn ${3}Reducer(state, action);",
-            "}"            
-        ]
-    },
-    "NgRx Reducer": {
-        "prefix": "ngrx-reducer",
-        "description": "NgRx reducer",
-        "body": [            
-            "const ${1:feature}Reducer = createReducer(",
-            "\tinitialState,",
-            "\ton(${2:action}, state => ({ ...state, ${3:prop}: ${4:newValue} })),",            
-            ");",
-            "export function reducer(state: State, action: Action) {",
-            "\treturn ${1}Reducer(state, action);",
-            "}"
-        ]
-    },
-    "NgRx Reducer Ons": {
-        "prefix": "ngrx-on",
-        "description": "NgRx Reducer 'On'",
-        "body": [
-            "on(${1:action}, state => ({ ...state, ${2:prop}: ${3:newValue} })),"
-        ]
-    },
-    "NgRx Select Store": {
-        "prefix": "ngrx-store-select",
-        "description": "NgRx select store",
-        "body": [
-            "this.store.pipe(select('${1:sliceOfState}'))"
-        ]
-    },
-    "NgRx Dispatch Action": {
-        "prefix": "ngrx-dispatch-action",
-        "description": "NgRx Dispatch Action",
-        "body": [
-            "this.store.dispatch(${1:ActionClass});"
-        ]
-    },
-    "NgRx Selector": {
-        "prefix": "ngrx-selector",
-        "description": "NgRx Selector",
-        "body": [
-            "export const ${4:getStateSlice} = () =>",
-            "\tcreateSelector(${1:getState}, (state: ${2:any}) => state${3:state});"
-        ]
-    },
-    "NgRx Feature Selector": {
-        "prefix": "ngrx-feat-selector",
-        "description": "NgRx Feature Selector",
-        "body": [
-            "export const get${3:state} = createFeatureSelector<${2:any}>('${1:selector}');"
-        ]
-    },
-    "NgRx Devtool Instrument": {
-        "prefix": "ngrx-devtool-instrument",
-        "description": "NgRx Devltool Instrument.\nimport { StoreDevtoolsModule } from '@ngrx/store-devtools'",
-        "body": [
-            "StoreDevtoolsModule.instrument({",
-            "\tmaxAge: ${1:maxAge},",
-            "\tlogOnly: false,",
-            "\tfeatures: {",
-            "\t\tpause: false,",
-            "\t\tlock: true,",
-            "\t\tpersist: true",
-            "\t}",
-            "})"
-        ]
-    },
-    "NgRx Entity Adapter Setup": {
-        "prefix": "ngrx-entity-adapter-setup",
-        "description": "NgRx Entity Adapter.",
-        "body": [
-            "import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';",
-            "",
-            "export interface ${1:CustomEntity} {",
-            "\t// define properties",
-            "}",
-            "",
-            "export interface State extends EntityState<${1}> {",
-            "\t// define entities state properties",
-            "}",            
-            "\n// define methods to be used in adapter\n",
-            "export const adapter: EntityAdapter<${1}> = createEntityAdapter<${1}>({",
-            "\t// define adapter methods",
-            "});"
-        ]
-    },
-    "NgRx Entities Setup": {
-        "prefix": "ngrx-entities-setup",
-        "description": "NgRx Entities Setup",
-        "body": [
-            "import { EntityMetadataMap } from '@ngrx/data';",
-            "",
-            "const entityMetadata: EntityMetadataMap = {",
-            "\t// define entities",
-            "}",
-            "",
-            "export const entityConfig = {",
-            "\t// entities",
-            "}"
-        ]
-    },
-    "NgRx Entity Store Registration": {
-        "prefix": "ngrx-entity-store-registration",
-        "description": "NgRx Entity Store Registration.\nimport { DefaultDataServiceConfig, EntityDataModule } from '@ngrx/data';",
-        "body": [
-            "EntityDataModule.forRoot([${1:entityConfig}])"
-        ]
-    },
-    "NgRx Entity Data Service": {
-        "prefix": "ngrx-entity-data-service",
-        "description": "NgRx Entity Data Service.",
-        "body": [
-            "import { Injectable } from '@angular/core';",
-            "import {",
-            "\tEntityCollectionServiceBase,",
-            "\tEntityCollectionServiceElementsFactory",
-            "\tQueryParams",
-            "} from '@ngrx/data';",
+  "NgRx Actions Setup": {
+    "prefix": "ngrx-actions-setup",
+    "description": "NgRx actions fully configured with action constants, creators with success and fail.",
+    "body": [
+      "import { Action } from '@ngrx/store';",
+      "",
+      "export const ${1:ACTION_CONST} = \"${1/[\\_]/ /g}\"",
+      "export const ${1}_SUCCESS = \"${1/[\\_]/ /g} SUCCESS\"",
+      "export const ${1}_FAIL = \"${1/[\\_]/ /g} FAIL\"",
+      "",
+      "export class ${2:ActionCreator} implements Action {",
+      "\treadonly type = ${1};",
+      "\tconstructor() { }",
+      "}\n",
+      "export class ${2}Success implements Action {",
+      "\treadonly type = ${1}_SUCCESS;",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export class ${2}Fail implements Action {",
+      "\treadonly type = ${1}_FAIL;",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export type Actions = ${2} | ${2}Success | ${2}Fail;"
+    ]
+  },
+  "NgRx Create Action Setup": {
+    "prefix": "ngrx-create-action-setup",
+    "description": "NgRx create action setup.",
+    "body": [
+      "import { createAction } from '@ngrx/store';",
+      "// ${1} action",
+      "export const ${1:action} = createAction('[${2:source}] ${3:event}');"
+    ]
+  },
+  "NgRx Create Action": {
+    "prefix": "ngrx-create-action",
+    "description": "NgRx create action.",
+    "body": [
+      "// ${1} action",
+      "export const ${1:action} = createAction('[${2:source}] ${3:event}');"
+    ]
+  },
+  "NgRx Create Action with Props": {
+    "prefix": "ngrx-create-action-props",
+    "description": "NgRx create action with props.",
+    "body": [
+      "// ${1} action",
+      "export const ${1:action} = createAction(",
+      "\t'[${2:source}] ${3:event}',",
+      "\t props<{${4:key}: ${5:type}}>()",
+      ");"
+    ]
+  },
+  "NgRx Actions CRUD Setup": {
+    "prefix": "ngrx-actions-setup-crud",
+    "description": "NgRx actions for CRUD operations.",
+    "body": [
+      "import { Action } from '@ngrx/store';",
+      "",
+      "export const ${1:ACTION_CONST} = \"${1/[\\_]/ /g}\"",
+      "export const ${1}_SUCCESS = \"${1/[\\_]/ /g} SUCCESS\"",
+      "export const ${1}_FAIL = \"${1/[\\_]/ /g} FAIL\"",
+      "",
+      "export class Load${2:ActionCreator} implements Action {",
+      "\treadonly type = ${1};",
+      "}\n",
+      "export class Load${2}Success implements Action {",
+      "\treadonly type = ${1}_SUCCESS;",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export class Load${2}Fail implements Action {",
+      "\treadonly type = ${1}_FAIL;",
+      "\tconstructor(public payload: any) { }",
+      "}",
+      "",
+      "export const CREATE_${3:ACTION_CONST} = \"CREATE ${3}\"",
+      "export const CREATE_${3}_SUCCESS = \"CREATE ${3} SUCCESS\"",
+      "export const CREATE_${3}_FAIL = \"CREATE ${3} FAIL\"",
+      "",
+      "export class Create${4:ActionCreator} implements Action {",
+      "\treadonly type = CREATE_${3};",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export class Create${4}Success implements Action {",
+      "\treadonly type = CREATE_${3}_SUCCESS;",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export class Create${4}Fail implements Action {",
+      "\treadonly type = CREATE_${3}_FAIL;",
+      "\tconstructor(public payload: any) { }",
+      "}",
+      "",
+      "export const UPDATE_${3} = \"UPDATE ${3}\"",
+      "export const UPDATE_${3}_SUCCESS = \"UPDATE ${3} SUCCESS\"",
+      "export const UPDATE_${3}_FAIL = \"UPDATE ${3} FAIL\"",
+      "",
+      "export class Update${4} implements Action {",
+      "\treadonly type = UPDATE_${3};",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export class Update${4}Success implements Action {",
+      "\treadonly type = UPDATE_${3}_SUCCESS;",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export class Update${4}Fail implements Action {",
+      "\treadonly type = UPDATE_${3}_FAIL;",
+      "\tconstructor(public payload: any) { }",
+      "}",
+      "",
+      "export const DELETE_${3} = \"DELETE ${3:ACTION_STR}\"",
+      "export const DELETE_${3}_SUCCESS = \"DELETE ${3} SUCCESS\"",
+      "export const DELETE_${3}_FAIL = \"DELETE ${3} FAIL\"",
+      "",
+      "export class Delete${4:ActionCreator} implements Action {",
+      "\treadonly type = DELETE_${3};",
+      "\tconstructor(public id: number) { }",
+      "}\n",
+      "export class Delete${4}Success implements Action {",
+      "\treadonly type = DELETE_${3}_SUCCESS;",
+      "\tconstructor(public payload: any) { }",
+      "}\n",
+      "export class Delete${4}Fail implements Action {",
+      "\treadonly type = DELETE_${3}_FAIL;",
+      "\tconstructor(public payload: any) { }",
+      "}",
+      "",
+      "export type Actions =",
+      "\t| Load${2}",
+      "\t| Load${2}Success",
+      "\t| Load${2}Fail",
+      "\t| Create${4}",
+      "\t| Create${4}Success",
+      "\t| Create${4}Fail",
+      "\t| Update${4}",
+      "\t| Update${4}Success",
+      "\t| Update${4}Fail",
+      "\t| Delete${4}",
+      "\t| Delete${4}Success",
+      "\t| Delete${4}Fail;",
+      ""
+    ]
+  },
+  "NgRx Basic Action": {
+    "prefix": "ngrx-action",
+    "description": "NgRx action constant and creator.",
+    "body": [
+      "export const ${1:ACTION_CONST} = \"${1/[\\_]/ /g}\"\n",
+      "export class ${2:ActionCreator} implements Action {",
+      "\treadonly type = ${1};",
+      "\tconstructor() { }",
+      "}\n"
+    ]
+  },
+  "NgRx Success Action": {
+    "prefix": "ngrx-action-success",
+    "description": "NgRx action constant and creator as success",
+    "body": [
+      "export const ${1:ACTION_CONST}_SUCCESS = \"${1/[\\_]/ /g} SUCCESS\"\n",
+      "export class ${2:ActionCreator}Success implements Action {",
+      "\treadonly type = ${1}_SUCCESS;",
+      "\tconstructor(public payload: any) { }",
+      "}\n"
+    ]
+  },
+  "NgRx Fail Action": {
+    "prefix": "ngrx-action-fail",
+    "description": "NgRx action constant and creator as  fail.",
+    "body": [
+      "export const ${1:ACTION_CONST}_FAIL = \"${1/[\\_]/ /g} FAIL\"\n",
+      "export class ${3:ActionCreator} implements Action {",
+      "\treadonly type = ${1}_FAIL;",
+      "\tconstructor(public payload: any) { }",
+      "}\n"
+    ]
+  },
+  "NgRx Effects Setup": {
+    "prefix": "ngrx-effect-setup",
+    "description": "NgRx effect setup",
+    "body": [
+      "import { Injectable } from '@angular/core';",
+      "import { Actions, createEffect, ofType } from '@ngrx/effects';",
+      "// import { EMPTY } from 'rxjs';",
+      "// import { map, mergeMap, catchError } from 'rxjs/operators';",
+      "",
+      "import * as ${2:alias} from '${1:actions}';",
+      "//import all requried services or any dependencies",
+      "",
+      "@Injectable()",
+      "export class ${3:Name}Effects {",
+      "\tconstructor(private actions$: Actions) { }",
+      "",
+      "\t${4:effectName}$ = createEffect(() =>",
+      "\t\tthis.actions$.pipe(",
+      "\t\t\tofType(${2}${5:action}),",
+      "\t\t\tmergeMap(() => {",
+      "\t\t\t\t/*this.myService.pipe(",
+      "\t\t\t\t\tmap(data => data)",
+      "\t\t\t\t\tcatchError(() => EMPTY)",
+      "\t\t\t\t*/",
+      "\t\t\t})",
+      "\t\t)",
+      "\t);",
+      "}"
+    ]
+  },
+  "NgRx Effect": {
+    "prefix": "ngrx-effect",
+    "description": "NgRx effect",
+    "body": [
+      "${1:effectName}$ = createEffect(() =>",
+      "\tthis.actions$.pipe(",
+      "\t\tofType(${2:action}),",
+      "\t\tmergeMap(() => {",
+      "\t\t\t/*this.myService.pipe(",
+      "\t\t\t\tmap(data => data)",
+      "\t\t\t\tcatchError(() => EMPTY)",
+      "\t\t\t*/",
+      "\t\t})",
+      "\t)",
+      ");"
+    ]
+  },
+  "NgRx Root Effect Registration": {
+    "prefix": "ngrx-root-effect-registration",
+    "description": "NgRx Root Effect Registration.\nimport { EffectsModule } from '@ngrx/effects';",
+    "body": ["EffectsModule.forRoot([${1:effect}])"]
+  },
+  "NgRx Feature Effect Registration": {
+    "prefix": "ngrx-feat-effect-registration",
+    "description": "NgRx Feature Effect Registration.\nimport { EffectsModule } from '@ngrx/effects';",
+    "body": ["EffectsModule.forFeature([${1:effect}])"]
+  },
+  "NgRx Reducer Setup": {
+    "prefix": "ngrx-reducer-setup",
+    "description": "NgRx reducer setup",
+    "body": [
+      "import { Action, createReducer, on } from '@ngrx/store';",
+      "import * as ${2:alias} from '${1:actions}';",
+      "",
+      "export interface State {",
+      "\t// define state ",
+      "};",
+      "",
+      "export const initialState = {",
+      "\t//set initial state",
+      "};",
+      "",
+      "const ${3:feature}Reducer = createReducer(",
+      "\tinitialState,",
+      "\ton(${2}${4:action}, state => ({ ...state, ${5:prop}: ${6:newValue} })),",
+      ");",
+      "export function reducer(state: State, action: Action) {",
+      "\treturn ${3}Reducer(state, action);",
+      "}"
+    ]
+  },
+  "NgRx Reducer": {
+    "prefix": "ngrx-reducer",
+    "description": "NgRx reducer",
+    "body": [
+      "const ${1:feature}Reducer = createReducer(",
+      "\tinitialState,",
+      "\ton(${2:action}, state => ({ ...state, ${3:prop}: ${4:newValue} })),",
+      ");",
+      "export function reducer(state: State, action: Action) {",
+      "\treturn ${1}Reducer(state, action);",
+      "}"
+    ]
+  },
+  "NgRx Reducer Ons": {
+    "prefix": "ngrx-on",
+    "description": "NgRx Reducer 'On'",
+    "body": [
+      "on(${1:action}, state => ({ ...state, ${2:prop}: ${3:newValue} })),"
+    ]
+  },
+  "NgRx Select Store": {
+    "prefix": "ngrx-store-select",
+    "description": "NgRx select store",
+    "body": ["this.store.pipe(select('${1:sliceOfState}'))"]
+  },
+  "NgRx Dispatch Action": {
+    "prefix": "ngrx-dispatch-action",
+    "description": "NgRx Dispatch Action",
+    "body": ["this.store.dispatch(${1:ActionClass});"]
+  },
+  "NgRx Selector": {
+    "prefix": "ngrx-selector",
+    "description": "NgRx Selector",
+    "body": [
+      "export const ${4:getStateSlice} = () =>",
+      "\tcreateSelector(${1:getState}, (state: ${2:any}) => state${3:state});"
+    ]
+  },
+  "NgRx Feature Selector": {
+    "prefix": "ngrx-feat-selector",
+    "description": "NgRx Feature Selector",
+    "body": [
+      "export const get${3:state} = createFeatureSelector<${2:any}>('${1:selector}');"
+    ]
+  },
+  "NgRx Devtool Instrument": {
+    "prefix": "ngrx-devtool-instrument",
+    "description": "NgRx Devltool Instrument.\nimport { StoreDevtoolsModule } from '@ngrx/store-devtools'",
+    "body": [
+      "StoreDevtoolsModule.instrument({",
+      "\tmaxAge: ${1:maxAge},",
+      "\tlogOnly: false,",
+      "\tfeatures: {",
+      "\t\tpause: false,",
+      "\t\tlock: true,",
+      "\t\tpersist: true",
+      "\t}",
+      "})"
+    ]
+  },
+  "NgRx Entity Adapter Setup": {
+    "prefix": "ngrx-entity-adapter-setup",
+    "description": "NgRx Entity Adapter.",
+    "body": [
+      "import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';",
+      "",
+      "export interface ${1:CustomEntity} {",
+      "\t// define properties",
+      "}",
+      "",
+      "export interface State extends EntityState<${1}> {",
+      "\t// define entities state properties",
+      "}",
+      "\n// define methods to be used in adapter\n",
+      "export const adapter: EntityAdapter<${1}> = createEntityAdapter<${1}>({",
+      "\t// define adapter methods",
+      "});"
+    ]
+  },
+  "NgRx Entities Setup": {
+    "prefix": "ngrx-entities-setup",
+    "description": "NgRx Entities Setup",
+    "body": [
+      "import { EntityMetadataMap } from '@ngrx/data';",
+      "",
+      "const entityMetadata: EntityMetadataMap = {",
+      "\t// define entities",
+      "}",
+      "",
+      "export const entityConfig = {",
+      "\t// entities",
+      "}"
+    ]
+  },
+  "NgRx Entity Store Registration": {
+    "prefix": "ngrx-entity-store-registration",
+    "description": "NgRx Entity Store Registration.\nimport { DefaultDataServiceConfig, EntityDataModule } from '@ngrx/data';",
+    "body": ["EntityDataModule.forRoot([${1:entityConfig}])"]
+  },
+  "NgRx Entity Data Service": {
+    "prefix": "ngrx-entity-data-service",
+    "description": "NgRx Entity Data Service.",
+    "body": [
+      "import { Injectable } from '@angular/core';",
+      "import {",
+      "\tEntityCollectionServiceBase,",
+      "\tEntityCollectionServiceElementsFactory",
+      "\tQueryParams",
+      "} from '@ngrx/data';",
 
-            "import { Observable } from 'rxjs';",
-            "import { ${2:model} } from '${1:modelPath}';",
-            "",
-            "@Injectable({ providedIn: 'root' })",
-            "export class ${2}Service extends EntityCollectionServiceBase<${2}> {",
-            "\tconstructor(serviceElementsFactory: EntityCollectionServiceElementsFactory) {",
-            "\t\tsuper('${2}', serviceElementsFactory);",
-            "\t}",
-            "",
-            "\tgetAll(): Observable<${2}[]> {",
-            "\t\treturn super.getAll().pipe(/*data manupulation*/);",
-            "\t}",
-            "",
-            "\tgetById(id: string | number): Observable<${2}> {",
-            "\t\treturn super.getById(id).pipe(/*data manupulation*/);",
-            "\t}",
-            "",
-            "\tgetWithQuery(params: string | QueryParams): Observable<${2}[]> {",
-            "\t\treturn super.getWithQuery(params).pipe(/*data manupulation*/);",
-            "\t}",
-            "}"
-        ]
-    }
+      "import { Observable } from 'rxjs';",
+      "import { ${2:model} } from '${1:modelPath}';",
+      "",
+      "@Injectable({ providedIn: 'root' })",
+      "export class ${2}Service extends EntityCollectionServiceBase<${2}> {",
+      "\tconstructor(serviceElementsFactory: EntityCollectionServiceElementsFactory) {",
+      "\t\tsuper('${2}', serviceElementsFactory);",
+      "\t}",
+      "",
+      "\tgetAll(): Observable<${2}[]> {",
+      "\t\treturn super.getAll().pipe(/*data manupulation*/);",
+      "\t}",
+      "",
+      "\tgetById(id: string | number): Observable<${2}> {",
+      "\t\treturn super.getById(id).pipe(/*data manupulation*/);",
+      "\t}",
+      "",
+      "\tgetWithQuery(params: string | QueryParams): Observable<${2}[]> {",
+      "\t\treturn super.getWithQuery(params).pipe(/*data manupulation*/);",
+      "\t}",
+      "}"
+    ]
+  }
 }


### PR DESCRIPTION
Closes #4 

## Changelog

* Reverted Typescript snippets for:
  * Effects and its setup to support [v7](https://v7.ngrx.io/guide/effects#writing-effects) style of using `@Effect()`
* Updated documentation [`README.md`](https://github.com/hardikpthv/vscode-ngrx-snippets/blob/master/README.md) for new snippets
* Updated Typescript snippets for:
  * `ngrx-effect-setup` -> make use of `createEffect`
  * `ngrx-effect` -> make use of `createEffect`
  * `ngrx-reducer-setup` -> make use of `createReducer`  
* Added Typescript snippets for:
  * `createAction` to create actions
    * `ngrx-create-action-setup`
    * `ngrx-create-action`
    * `ngrx-create-action-props`
  * `ngrx-root-effect-registration` to register effect in root module
  * `ngrx-feat-effect-registration` to register effect in feature module
  * `createReducer` to create reducers
    * `ngrx-reducer`
    * `ngrx-on` -> make use of `on`
  * `StoreDevtoolsModule.instrument` configuration
  * `createEntityAdapter` to create entity adapter 
    * `ngrx-entity-adapter-setup`
  * `EntityMetadataMap` to setup entities
    * `ngrx-entities-setup`
    * `ngrx-entity-store-registration` to register entity store
  * `ngrx-entity-data-service` to create data service using `tEntityCollectionServiceBase`, `tEntityCollectionServiceElementsFactory` and other utility methods.